### PR TITLE
ConnectToMySQL: Escape commas and semi-colons

### DIFF
--- a/Assets/ConnectToMySQL/ConnectToMySQL.cs
+++ b/Assets/ConnectToMySQL/ConnectToMySQL.cs
@@ -210,6 +210,16 @@ public class ConnectToMySQL : MonoBehaviour {
 		for(int i = 0; i < logCollection["Email"].Count; i++) {
 			List<string> row = new List<string>();
 			foreach(string key in logCollection.Keys) {
+				if (logCollection[key][i].Contains(",")) {
+					Debug.LogWarning("Value " + logCollection[key] + "from column " + key + "contains comma (,). It has been replaced with a dot.");
+					logCollection[key][i].Replace(',', '.');
+				} else if (logCollection[key][i].Contains(";")) {
+					Debug.LogWarning("Value " + logCollection[key] + "from column " + key + "contains semi-colon (;). It has been replaced with a dash.");
+					logCollection[key][i].Replace(';', '-');
+				} else if (logCollection[key][i].Contains("\"")) {
+					Debug.LogWarning("Value " + logCollection[key] + "from column " + key + "contains quotation mark (\"). It has been replaced with a dash.");
+					logCollection[key][i].Replace('\"', '-');
+				}
 				row.Add(logCollection[key][i]);
 			}
 			if(i != 0) {


### PR DESCRIPTION
Until now the ConnectToMySQL package have not really
checked what data is being sent. As a result, it was
possible to break the connection to the database if
data contained commas or semi-colons.

To prevent this, replace commas with dots (.) and
semi-colons with dashes (-).