### PR TITLE
ConnectToMySQL: Trim newline characters from creds

### DIFF
--- a/Assets/ConnectToMySQL/ConnectToMySQL.cs
+++ b/Assets/ConnectToMySQL/ConnectToMySQL.cs
@@ -445,7 +445,7 @@ public class ConnectToMySQL : MonoBehaviour {
 		string[] lines = builtInCredentials.text.Split('\n');
 		foreach (var line in lines) {
 			if (!string.IsNullOrEmpty(line)) {
-				cred = line.Split('=');
+				cred = line.Trim().Split('=');
 				credentials[cred[0]] = cred[1];
 			}
 		}


### PR DESCRIPTION
The presence of newline characters was preventing
ConnectToMySQL to properly authenticate with the
database. To fix this, add Trim() in each line.
(Credit goes to Quentin for finding and suggesting
solution for this)